### PR TITLE
Settings: Incall vibration option [3/3]

### DIFF
--- a/res/xml/accessibility_vibration_intensity_settings.xml
+++ b/res/xml/accessibility_vibration_intensity_settings.xml
@@ -85,4 +85,27 @@
 
     </PreferenceCategory>
 
+    <!-- Incall vibration options -->
+    <PreferenceCategory
+        android:key="accessibility_incall_vibration_category"
+        android:title="@string/incall_vibration_category"
+        app:controller="com.android.settings.sound.IncallFeedbackPreferenceController">
+
+        <com.android.settings.preferences.SystemSettingSwitchPreference
+            android:key="vibrate_on_connect"
+            android:title="@string/incall_vibrate_connect_title"
+            android:defaultValue="true" />
+
+        <com.android.settings.preferences.SystemSettingSwitchPreference
+            android:key="vibrate_on_callwaiting"
+            android:title="@string/incall_vibrate_call_wait_title"
+            android:defaultValue="true" />
+
+        <com.android.settings.preferences.SystemSettingSwitchPreference
+            android:key="vibrate_on_disconnect"
+            android:title="@string/incall_vibrate_disconnect_title"
+            android:defaultValue="true" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/res/xml/accessibility_vibration_settings.xml
+++ b/res/xml/accessibility_vibration_settings.xml
@@ -85,4 +85,27 @@
 
     </PreferenceCategory>
 
+    <!-- Incall vibration options -->
+    <PreferenceCategory
+        android:key="accessibility_incall_vibration_category"
+        android:title="@string/incall_vibration_category"
+        app:controller="com.android.settings.sound.IncallFeedbackPreferenceController">
+
+        <com.android.settings.preferences.SystemSettingSwitchPreference
+            android:key="vibrate_on_connect"
+            android:title="@string/incall_vibrate_connect_title"
+            android:defaultValue="true" />
+
+        <com.android.settings.preferences.SystemSettingSwitchPreference
+            android:key="vibrate_on_callwaiting"
+            android:title="@string/incall_vibrate_call_wait_title"
+            android:defaultValue="true" />
+
+        <com.android.settings.preferences.SystemSettingSwitchPreference
+            android:key="vibrate_on_disconnect"
+            android:title="@string/incall_vibrate_disconnect_title"
+            android:defaultValue="true" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/src/com/android/settings/sound/IncallFeedbackPreferenceController.java
+++ b/src/com/android/settings/sound/IncallFeedbackPreferenceController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 The PixelExperience Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.sound;
+
+import android.content.Context;
+import android.telephony.TelephonyManager;
+
+import com.android.settings.core.BasePreferenceController;
+
+public class IncallFeedbackPreferenceController extends BasePreferenceController {
+
+    public IncallFeedbackPreferenceController(Context context, String key) {
+        super(context, key);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return isVoiceCapable() ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    private boolean isVoiceCapable() {
+        TelephonyManager telephony =
+                (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+        return telephony != null && telephony.isVoiceCapable();
+    }
+
+}


### PR DESCRIPTION
* allow setting vibration when call is connected
* allow setting vibration when call is disconnected
* allow setting vibration for call waiting
* this works with google and aosp dialer :)

Adapted to PE

[arrow-13.0]:
- Move inside accessibility_vibration_settings as all the aosp vibration toggles are there

includes:
fixup! Settings: incall vibration options [3/3]

[ghostrider-reborn]
- Enable by default
- Add to the slider-based prefs page as well

Change-Id: I55e99f501a3af07287c57a23939666351f4cef67