### PR TITLE
Settings: Add lockscreen charging info preferences

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13828,6 +13828,13 @@
     <string name="lockscreen_double_line_clock_summary">Clock size changes according to lock screen content</string>
     <!-- Lockscreen dynamic clock toggle [CHAR LIMIT=60] -->
     <string name="lockscreen_double_line_clock_setting_toggle">Dynamic clock</string>
+
+    <!-- Charging info -->
+    <string name="lockscreen_charging_info_title">Charging info</string>
+    <string name="lockscreen_charging_info_summary">Show charging status on the lock screen</string>
+    <string name="lockscreen_charging_info_details_title">Show detailed info</string>
+    <string name="lockscreen_charging_info_details_summary">Show current, voltage, power and battery temperature while charging</string>
+
     <!-- Lock screen shortcuts preference [CHAR LIMIT=60] -->
     <string name="lockscreen_quick_affordances_title">Shortcuts</string>
     <!-- Summary for the lock screen button preference [CHAR LIMIT=60] -->

--- a/res/xml/security_lockscreen_settings.xml
+++ b/res/xml/security_lockscreen_settings.xml
@@ -121,6 +121,19 @@
             android:title="@string/lockscreen_double_line_clock_setting_toggle"
             android:summary="@string/lockscreen_double_line_clock_summary"
             settings:controller="com.android.settings.display.LockscreenClockPreferenceController" />
+
+        <com.android.settings.preferences.SecureSettingSwitchPreference
+            android:key="lockscreen_charging_info"
+            android:title="@string/lockscreen_charging_info_title"
+            android:summary="@string/lockscreen_charging_info_summary"
+            android:defaultValue="true" />
+
+        <com.android.settings.preferences.SecureSettingSwitchPreference
+            android:key="lockscreen_charging_info_details"
+            android:title="@string/lockscreen_charging_info_details_title"
+            android:summary="@string/lockscreen_charging_info_details_summary"
+            android:dependency="lockscreen_charging_info"
+            android:defaultValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Introduce a toggle to show charging information on the lockscreen, along with a dependent option to display additional details such as current, voltage, power, and battery temperature.

The detailed toggle is only available when charging info is enabled, ensuring a clean and intuitive settings hierarchy.

Change-Id: I48275937b0e3ba39d51abd54571d23416fe08f54