### PR TITLE
Settings:  Add check to prevent duplicate HDR toggles

### DIFF
--- a/src/com/android/settings/display/HdrDisplayBrightnessPreferenceController.java
+++ b/src/com/android/settings/display/HdrDisplayBrightnessPreferenceController.java
@@ -31,6 +31,9 @@ public class HdrDisplayBrightnessPreferenceController extends BasePreferenceCont
 
     @Override
     public int getAvailabilityStatus() {
+        if (HdrBrightnessUtils.getAvailabilityStatus(mContext) == AVAILABLE) {
+            return UNSUPPORTED_ON_DEVICE;
+        }
         return SystemProperties.getBoolean("ro.surface_flinger.has_HDR_display", false)
                 ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }

--- a/src/com/android/settings/display/HdrDisplayPreferenceController.java
+++ b/src/com/android/settings/display/HdrDisplayPreferenceController.java
@@ -48,6 +48,9 @@ public class HdrDisplayPreferenceController extends TogglePreferenceController
 
     @Override
     public int getAvailabilityStatus() {
+        if (HdrBrightnessUtils.getAvailabilityStatus(mContext) == AVAILABLE) {
+            return UNSUPPORTED_ON_DEVICE;
+        }
         return SystemProperties.getBoolean("ro.surface_flinger.has_HDR_display", false)
                 ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }


### PR DESCRIPTION
Add condition to only show custom HDR display switch and brightness slider if AOSP implementation isnt visible even when device display supports HDR

Change-Id: I8fbb6197a1dcfffc5f35eddf0d1ca92ea832d3d7

<img width="582" height="1280" alt="image" src="https://github.com/user-attachments/assets/b934e918-de2d-4db3-8447-13fd8233ea81" />

<img width="1264" height="627" alt="image" src="https://github.com/user-attachments/assets/7b6ee9fe-f20f-4fc7-a15f-6f70f924e637" />
